### PR TITLE
Typo fixes and set defaults in states

### DIFF
--- a/oracle-java/init.sls
+++ b/oracle-java/init.sls
@@ -5,8 +5,8 @@
 # Automatically accept the oracle license
 Accept Oracle Terms:
   debconf.set:
-    - name: oracle-java6-installer 
-    - data: 
+    - name: oracle-java6-installer
+    - data:
         'shared/accepted-oracle-license-v1-1': {'type': 'boolean', 'value': True }
 
 # Configure apt to use the WEB UPD8 repo
@@ -47,4 +47,3 @@ oracle-java6-installer:
     - require:
       - pkgrepo: webupd8-repo
       - debconf: Accept Oracle Terms
-

--- a/oracle-java/java6.sls
+++ b/oracle-java/java6.sls
@@ -9,8 +9,8 @@
 # Automatically accept the oracle license
 Accept Oracle6 Terms:
   debconf.set:
-    - name: oracle-java6-installer 
-    - data: 
+    - name: oracle-java6-installer
+    - data:
         'shared/accepted-oracle-license-v1-1': {'type': 'boolean', 'value': True }
 
 # Include US security files.
@@ -33,4 +33,3 @@ oracle-java6-installer:
     - require:
       - pkgrepo: webupd8-repo
       - debconf: Accept Oracle6 Terms
-

--- a/oracle-java/java7.sls
+++ b/oracle-java/java7.sls
@@ -9,8 +9,8 @@
 # Automatically accept the oracle license
 Accept Oracle7 Terms:
   debconf.set:
-    - name: oracle-java7-installer 
-    - data: 
+    - name: oracle-java7-installer
+    - data:
         'shared/accepted-oracle-license-v1-1': {'type': 'boolean', 'value': True }
 
 # Run the installer itself
@@ -21,3 +21,8 @@ oracle-java7-installer:
       - pkgrepo: webupd8-repo
       - debconf: Accept Oracle7 Terms
 
+oracle-java7-set-default:
+  pkg:
+    - installed
+    - require:
+      - pkg: oracle-java7-installer

--- a/oracle-java/java8.sls
+++ b/oracle-java/java8.sls
@@ -7,10 +7,10 @@
 {% include 'oracle-java/common.sls' %}
 
 # Automatically accept the oracle license
-Accept Oracle7 Terms:
+Accept Oracle8 Terms:
   debconf.set:
-    - name: oracle-java8-installer 
-    - data: 
+    - name: oracle-java8-installer
+    - data:
         'shared/accepted-oracle-license-v1-1': {'type': 'boolean', 'value': True }
 
 # Run the installer itself
@@ -20,4 +20,3 @@ oracle-java8-installer:
     - require:
       - pkgrepo: webupd8-repo
       - debconf: Accept Oracle8 Terms
-

--- a/oracle-java/map.jinja
+++ b/oracle-java/map.jinja
@@ -4,7 +4,6 @@
       'java_home': '/usr/lib/jvm/java-'+ java_version + '-oracle',
     },
   },
-  merge=salt['pillar.get']('oracle-java:lookup') 
+  merge=salt['pillar.get']('oracle-java:lookup')
 )
 %}
-


### PR DESCRIPTION
Fixed a typo in java8 state.
Added oracle-java-*-set-default because it just makes sense.
